### PR TITLE
98selinux-microos: Don't rely on selinux=1 (bsc#1202449)

### DIFF
--- a/selinux/98selinux-microos/selinux-microos-relabel.sh
+++ b/selinux/98selinux-microos/selinux-microos-relabel.sh
@@ -3,7 +3,7 @@
 rd_is_selinux_enabled()
 {
     # If SELinux is not enabled exit now
-    getarg "selinux=1" > /dev/null || return 1
+    grep -qw selinux /sys/kernel/security/lsm || return 1
 
     SELINUX="enforcing"
     [ -e "$NEWROOT/etc/selinux/config" ] && . "$NEWROOT/etc/selinux/config"


### PR DESCRIPTION
security=selinux or even builtin kernel defaults are enough to enable selinux,
so checking for selinux=1 specifically is not enough.