### PR TITLE
98selinux-microos: Make the btrfs subvolume writable temporarily (boo#1202395)

### DIFF
--- a/selinux/98selinux-microos/module-setup.sh
+++ b/selinux/98selinux-microos/module-setup.sh
@@ -14,5 +14,5 @@ depends() {
 # called by dracut
 install() {
     inst_hook pre-pivot 50 "$moddir/selinux-microos-relabel.sh"
-    inst_multiple grep setenforce
+    inst_multiple cut grep setenforce
 }

--- a/selinux/98selinux-microos/selinux-microos-relabel.sh
+++ b/selinux/98selinux-microos/selinux-microos-relabel.sh
@@ -53,9 +53,12 @@ rd_microos_relabel()
 		mkdir -p "${ROOT_SELINUX}"
 		mount --rbind --make-rslave "${NEWROOT}" "${ROOT_SELINUX}"
 		mount -o remount,rw "${ROOT_SELINUX}"
+                oldrovalue="$(btrfs prop get "${ROOT_SELINUX}" ro | cut -d= -f2)"
+                btrfs prop set "${ROOT_SELINUX}" ro false
                 FORCE=
 		[ -e "${ROOT_SELINUX}"/etc/selinux/.autorelabel ] && FORCE="$(cat "${ROOT_SELINUX}"/etc/selinux/.autorelabel)"
 		LANG=C chroot "${ROOT_SELINUX}" /sbin/restorecon $FORCE -R -e /var/lib/overlay -e /sys -e /dev -e /run /
+                btrfs prop set "${ROOT_SELINUX}" ro "${oldrovalue}"
 		umount -R "${ROOT_SELINUX}"
             fi
 	fi


### PR DESCRIPTION
Previously this relied on a kernel bug: It was possible to change xattrs of
files on read-only subvolumes.