### PR TITLE
98selinux-microos: Add chroot as dependency

### DIFF
--- a/selinux/98selinux-microos/module-setup.sh
+++ b/selinux/98selinux-microos/module-setup.sh
@@ -14,5 +14,5 @@ depends() {
 # called by dracut
 install() {
     inst_hook pre-pivot 50 "$moddir/selinux-microos-relabel.sh"
-    inst_multiple cut grep setenforce
+    inst_multiple chroot cut grep setenforce
 }


### PR DESCRIPTION
`chroot` is not unconditionally installed in the initrd since https://github.com/dracutdevs/dracut/commit/51813371

This fix is needed for dracut-059, issue found in https://build.opensuse.org/request/show/1046083

```
Jan 03 11:07:26 localhost dracut-pre-pivot[511]: SELinux: relabeling root filesystem
Jan 03 11:07:26 localhost dracut-pre-pivot[511]: SELinux: loading policy
Jan 03 11:07:26 localhost dracut-pre-pivot[511]: //lib/dracut/hooks/pre-pivot/50-selinux-microos-relabel.sh: line 44: chroot: command not found
```