### PR TITLE
Make relabeling a little more obvious that it's happening

### DIFF
--- a/selinux/selinux-autorelabel-generator
+++ b/selinux/selinux-autorelabel-generator
@@ -40,7 +40,9 @@ enable_units() {
 
 		[Service]
 		Type=oneshot
+   		ExecStartPre=/bin/sh -c "echo SELinux relabeling ${realdir}"
 		ExecStart=/sbin/restorecon -R ${opts} ${realdir}
+                StandardOutput=journal+console
 	EOF
 
 	ln -sf ../"${unitfile}" "${generatordir}"/local-fs.target.requires/"${unitfile}"


### PR DESCRIPTION
Right now SELinux relabelling can take an excessively long time, particularly on some drives and full mounts, and this happens entirely silently.

As I lost the argument about labelling less often or not quite so broadly across the filesystem, I'm still seeking ways to address the impact this has on users with large amounts of data in locations like /srv and /home

This small change to the generator at least means people have some indication as to what is going on and gives the user the opportunity to imply which dirs are taking longer to relabel

I'd particularly like this on Aeon where our boot is plymouth-free and normally silent.
This approach obviously breaks that silence, but I think with good reason - 5 minute plus boot needs to be justified.