### PR TITLE
Use all cores for SELinux restorecon

### DIFF
--- a/selinux/98selinux-microos/selinux-microos-relabel.sh
+++ b/selinux/98selinux-microos/selinux-microos-relabel.sh
@@ -51,13 +51,13 @@ rd_microos_relabel()
         . "${ROOT_SELINUX}"/etc/selinux/config
         # Marker when we had relabelled the filesystem. This is relabelled as well.
         > "${ROOT_SELINUX}"/etc/selinux/.relabelled
-        LANG=C chroot "$ROOT_SELINUX" /sbin/setfiles $FORCE -e /var/lib/overlay -e /proc -e /sys -e /dev -e /etc "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" $(chroot "$ROOT_SELINUX" cut -d" " -f2 /proc/mounts)
+        LANG=C chroot "$ROOT_SELINUX" /sbin/setfiles $FORCE -T 0 -e /var/lib/overlay -e /proc -e /sys -e /dev -e /etc "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" $(chroot "$ROOT_SELINUX" cut -d" " -f2 /proc/mounts)
         # On overlayfs, st_dev isn't consistent so setfiles thinks it's a different mountpoint, ignoring it.
         # st_dev changes also on copy-up triggered by setfiles itself, so the only way to relabel properly
         # is to list every file explicitly.
         # That's not all: There's a kernel bug that security.selinux of parent directories is lost on copy-up (bsc#1210690).
         # Work around that by visiting children first and only then the parent directories.
-        LANG=C chroot "$ROOT_SELINUX" find /etc -depth -exec /sbin/setfiles $FORCE "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" \{\} +
+        LANG=C chroot "$ROOT_SELINUX" find /etc -depth -exec /sbin/setfiles $FORCE -T 0 "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" \{\} +
         btrfs prop set "${ROOT_SELINUX}" ro "${oldrovalue}"
     fi
 

--- a/selinux/98selinux-microos/selinux-microos-relabel.sh
+++ b/selinux/98selinux-microos/selinux-microos-relabel.sh
@@ -57,7 +57,7 @@ rd_microos_relabel()
         # is to list every file explicitly.
         # That's not all: There's a kernel bug that security.selinux of parent directories is lost on copy-up (bsc#1210690).
         # Work around that by visiting children first and only then the parent directories.
-        LANG=C chroot "$ROOT_SELINUX" find /etc -depth -exec /sbin/setfiles $FORCE -T 0 "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" \{\} +
+        LANG=C chroot "$ROOT_SELINUX" find /etc -depth -exec /sbin/setfiles $FORCE "/etc/selinux/${SELINUXTYPE}/contexts/files/file_contexts" \{\} +
         btrfs prop set "${ROOT_SELINUX}" ro "${oldrovalue}"
     fi
 

--- a/selinux/selinux-autorelabel-generator
+++ b/selinux/selinux-autorelabel-generator
@@ -27,8 +27,8 @@ enable_units() {
 	unitfile="${mountunit}-relabel.service"
 	relabel_unit_list="$unitfile $relabel_unit_list"
 
-	opts=""
-	[ "${realdir}" == "/.snapshots" ] && opts="-x"
+	opts="-T 0"
+	[ "${realdir}" == "/.snapshots" ] && opts="-T 0 -x"
 
 	cat >"${generatordir}/${unitfile}" <<-EOF
 		[Unit]

--- a/selinux/selinux-autorelabel-generator
+++ b/selinux/selinux-autorelabel-generator
@@ -28,7 +28,7 @@ enable_units() {
 	relabel_unit_list="$unitfile $relabel_unit_list"
 
 	opts="-T 0"
-	[ "${realdir}" == "/.snapshots" ] && opts="-T 0 -x"
+	[ "${realdir}" == "/.snapshots" ] && opts="${opts} -x"
 
 	cat >"${generatordir}/${unitfile}" <<-EOF
 		[Unit]


### PR DESCRIPTION
restorecon has the -T option to set how many cores are used for setting labels

The default is 1

Setting -T 0 uses all cores, which makes perfect sense considering we're blocking the boot while restoring here - those cores aren't going to be doing anything else

On an old Dell XPS13 this results in the following kind of speedup

2476k files with default single threaded operation - 2m23.455s

same fileset with -T 0 (4 core CPU) - 1m3.572s

That's quite a speedbost IMO
