### PR TITLE
Fix OBS workflow for pushes to master

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,10 +9,9 @@ ci_workflow:
 
 master_workflow:
   steps:
-    - branch_package:
-        source_project: devel:microos:ci:microos-tools
-        source_package: microos-tools
-        target_project: devel:microos:ci:microos-tools
+    - trigger_services:
+        project: devel:microos:ci:microos-tools
+        package: microos-tools
   filters:
     event: push
     branches:


### PR DESCRIPTION
Branching within a project creates links which accumulate. Use trigger_services instead.