### PR TITLE
Regenerate initrd after selinux-autorelabel installation

### DIFF
--- a/microos-tools.spec
+++ b/microos-tools.spec
@@ -69,19 +69,14 @@ This package contains tools to make developing of MicroOS easier.
 %pre
 %service_add_pre setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
 
-%post
-%{regenerate_initrd_post}
-%service_add_post setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
-
 %preun
 %service_del_preun setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
 
-%postun
-%{regenerate_initrd_post}
-%service_del_postun setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
+%post
+%service_add_post setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
 
-%posttrans
-%{regenerate_initrd_posttrans}
+%postun
+%service_del_postun setup-systemd-proxy-env.service setup-systemd-proxy-env.path printenv.service
 
 %pre -n microos-devel-tools
 %service_add_pre microos-ro.service
@@ -94,6 +89,15 @@ This package contains tools to make developing of MicroOS easier.
 
 %postun -n microos-devel-tools
 %service_del_postun microos-ro.service
+
+%post -n selinux-autorelabel
+%{regenerate_initrd_post}
+
+%postun -n selinux-autorelabel
+%{regenerate_initrd_post}
+
+%posttrans -n selinux-autorelabel
+%{regenerate_initrd_posttrans}
 
 %files
 %dir %{_sysconfdir}/selinux


### PR DESCRIPTION
ATM it's only triggered for the main package, which works on Micro, but on TW this will be used standalone