### PR TITLE
Add RemainAfterExit=true to autorelabel services

### DIFF
--- a/selinux/selinux-autorelabel-generator
+++ b/selinux/selinux-autorelabel-generator
@@ -43,6 +43,7 @@ enable_units() {
 			[Service]
 			Type=oneshot
 			ExecStart=/sbin/restorecon -R ${opts} ${realdir}
+			RemainAfterExit=true
 		EOF
 
 		ln -sf ../"${unitfile}" "${generatordir}"/local-fs.target.requires/"${unitfile}"
@@ -62,7 +63,8 @@ enable_units() {
 		[Service]
 		Type=oneshot
 		ExecStart=/usr/bin/rm /etc/selinux/.autorelabel
-EOF
+		RemainAfterExit=true
+	EOF
 
 	ln -sf "../${unitfile}" "${generatordir}/local-fs.target.requires/${unitfile}"
 }


### PR DESCRIPTION
Otherwise they'll never be considered active and local-fs.target will never be fully reached. Anything triggering multiple starts of local-fs.target would start the -relabel services again, eventually failing due to start-limit-hit.