### PR TITLE
Remove man-online.sh

### DIFF
--- a/man-online.sh
+++ b/man-online.sh
@@ -1,4 +1,0 @@
-# install alias if no local man is installed
-if [ "$is" = 'bash' ] && ! type -P man >/dev/null; then
-    alias man=man-online
-fi


### PR DESCRIPTION
Aliasing "man" to "man-online" can present the user with misleading information due to fetching current pages which might be out of sync with the installed version.

For example, fetching the page [`man 5 podman-systemd.unit`](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) within Leap 6.1 which has [podman 5.0.3](https://docs.podman.io/en/v5.0.3/markdown/podman-systemd.unit.5.html) will inform the user about features only present starting from 5.2.0 ([support for .build files](https://github.com/containers/podman/releases/tag/v5.2.0)). I'm not sure removing the alias altogether is the best approach, but I'm opening this regardless to keep track of this. At the end of day, wrong information is just wrong.