### PR TITLE
Only autorelabel local filesystems with SELinux support (boo#1237202)

### DIFF
--- a/selinux/selinux-autorelabel-generator
+++ b/selinux/selinux-autorelabel-generator
@@ -21,7 +21,8 @@ enable_units() {
 		# Skip non-fs (swap) mounts, /, /var, /etc (already done in the initrd) and mountpoints with noauto
 		if [ "${realdir:0:1}" != "/" ] \
 		   || [ "${realdir}" = "/" ] || [ "${realdir}" = "/var" ] || [ "${realdir}" = "/etc" ] \
-		   || findmnt --fstab --noheadings --output OPTIONS --target "${realdir}" | grep -qw noauto; then
+		   || ! findmnt --fstab --noheadings --output FSTYPE --target / | grep -qE '^(ext2|ext3|ext4|xfs|btrfs|jfs)$' \
+		   || findmnt --fstab --noheadings --output OPTIONS --target "${realdir}" | grep -qwE 'noauto|x-systemd\.automount|_netdev'; then
 			continue
 		fi
 


### PR DESCRIPTION
Skip remote and automount filesystems and those without support for labelling.