### PR TITLE
test: Wait for sshd.service before checking labels in /etc

### DIFF
--- a/test/testscript
+++ b/test/testscript
@@ -37,6 +37,9 @@ EOF
 chmod a+x /usr/bin/combustion-validate
 
 cat >>/etc/systemd/system/combustion-validate.service <<'EOF'
+[Unit]
+# This creates files in /etc/ssh/, make sure it's done.
+After=sshd.service
 [Service]
 Type=oneshot
 StandardOutput=journal+console


### PR DESCRIPTION
While sshd.service starts, the labels inside are not fully consistent with the policy, leading to false positives like:

[   13.887904] combustion-validate[1602]: Would relabel /etc/ssh/ssh_host_rsa_key.XXXXzVExEt from system_u:object_r:sshd_key_t:s0 to system_u:object_r:etc_t:s0