### PR TITLE
man-online: fix wrong section check (#42)

### DIFF
--- a/man-online
+++ b/man-online
@@ -45,7 +45,7 @@ done
 tmpdir=$(mktemp -d -t addimageencryption.XXXXXX)
 trap cleanup EXIT
 
-if [ -z "$section" ] && [ "${1/#[0-9]/}" != "$1" ]; then
+if [ -z "$section" ] && [ "${1/.#[0-9]/}" != "$1" ]; then
     section="$1"
     shift
 fi


### PR DESCRIPTION
man-online was only checking for a number to find out if there is a specific section requested, which fails if the manual page name contains already numbers. Checks for a number with a dot prefixed.