### PR TITLE
Only parse section with at minimum two arguments (#42)

### DIFF
--- a/man-online
+++ b/man-online
@@ -45,7 +45,7 @@ done
 tmpdir=$(mktemp -d -t addimageencryption.XXXXXX)
 trap cleanup EXIT
 
-if [ -z "$section" ] && [ "${1/#[0-9]/}" != "$1" ]; then
+if [ -z "$section" ] && [ "$#" -gt 1 ] && [ "${1/#[0-9]/}" != "$1" ]; then
     section="$1"
     shift
 fi


### PR DESCRIPTION
If we have only one argument and the manual page starts with a number (2ping, 8tunnel), man-online interprets this as section.