### PR TITLE
98selinux-microos: Also include parent devices needed for /var

### DIFF
--- a/selinux/98selinux-microos/module-setup.sh
+++ b/selinux/98selinux-microos/module-setup.sh
@@ -17,6 +17,7 @@ check() {
                 push_host_devs "$_dev"
                 if [[ -z ${host_fs_types["$_dev"]} ]]; then
                     host_fs_types["$_dev"]="$_fstype"
+                    check_block_and_slaves_all _get_fs_type "$(get_maj_min "$_dev")"
                 fi
             fi
         fi


### PR DESCRIPTION
This fixes cases where /var needs other devices to become available. Need to call an internal dracut function to make this simple...

~Draft because this needs more testing.~