### PR TITLE
Use single rpmtrans with libzypp by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = 1.6 foreign check-news dist-xz
 
-SUBDIRS = systemd-printenv tmpfs selinux devel-tools import-pubring
+SUBDIRS = systemd-printenv tmpfs selinux devel-tools import-pubring zypp-single-rpmtrans
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_PREFIX_DEFAULT(/usr)
 AC_SUBST(PACKAGE)
 AC_SUBST(VERSION)
 
+PKG_CHECK_VAR([systemdutildir], [systemd], [systemdutildir], [],
+        [AC_MSG_ERROR([Could not determine value for 'systemdutildir' - is the 'systemd.pc' file installed?])])
 PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir], [],
 	[AC_MSG_ERROR([Could not determine value for 'systemdsystemunitdir' - is the 'systemd.pc' file installed?])])
 PKG_CHECK_VAR([tmpfilesdir], [systemd], [tmpfilesdir], [],
@@ -31,5 +33,6 @@ AC_PROG_LN_S
 AC_CONFIG_FILES([Makefile systemd-printenv/Makefile \
 	tmpfs/Makefile selinux/Makefile \
 	import-pubring/Makefile \
+	zypp-single-rpmtrans/Makefile \
 	devel-tools/Makefile])
 AC_OUTPUT

--- a/zypp-single-rpmtrans/10-zypp-single-rpmtrans.conf
+++ b/zypp-single-rpmtrans/10-zypp-single-rpmtrans.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=ZYPP_SINGLE_RPMTRANS=1

--- a/zypp-single-rpmtrans/Makefile.am
+++ b/zypp-single-rpmtrans/Makefile.am
@@ -1,0 +1,7 @@
+systemdconfdir = $(systemdutildir)/system.conf.d
+systemdconf_DATA = 10-zypp-single-rpmtrans.conf
+
+profiledir = $(prefix)$(sysconfdir)/profile.d
+profile_DATA = zypp-single-rpmtrans.sh
+
+EXTRA_DIST = $(DATA)

--- a/zypp-single-rpmtrans/zypp-single-rpmtrans.sh
+++ b/zypp-single-rpmtrans/zypp-single-rpmtrans.sh
@@ -1,0 +1,1 @@
+export ZYPP_SINGLE_RPMTRANS=1


### PR DESCRIPTION
Set ZYPP_SINGLE_RPMTRANS=1 on commandline and for systemd servcies, so that libzypp will use single rpmtrans where ever called.